### PR TITLE
Allow runtime Mongo and secret setup

### DIFF
--- a/src/app/edit/[slug]/page.tsx
+++ b/src/app/edit/[slug]/page.tsx
@@ -2,6 +2,8 @@ import {getPrint} from "@/lib/data";
 import {redirect} from "next/navigation";
 import {Editor} from "@/app/edit/components/Editor";
 
+export const dynamic = 'force-dynamic'
+
 export default async function Page({
                                        params,
                                    }: {

--- a/src/app/edit/[slug]/page.tsx
+++ b/src/app/edit/[slug]/page.tsx
@@ -2,8 +2,6 @@ import {getPrint} from "@/lib/data";
 import {redirect} from "next/navigation";
 import {Editor} from "@/app/edit/components/Editor";
 
-export const dynamic = 'force-dynamic'
-
 export default async function Page({
                                        params,
                                    }: {

--- a/src/app/edit/page.tsx
+++ b/src/app/edit/page.tsx
@@ -7,8 +7,6 @@ import {revalidate} from "@/app/edit/actions/revalidate";
 import {deletePrintAction} from "@/app/edit/actions/deletePrintAction";
 import Link from "next/link";
 
-export const dynamic = 'force-dynamic'
-
 export default async function EditPage() {
     if (!await isLoggedIn()) {
         return redirect("/login")

--- a/src/app/edit/page.tsx
+++ b/src/app/edit/page.tsx
@@ -7,6 +7,8 @@ import {revalidate} from "@/app/edit/actions/revalidate";
 import {deletePrintAction} from "@/app/edit/actions/deletePrintAction";
 import Link from "next/link";
 
+export const dynamic = 'force-dynamic'
+
 export default async function EditPage() {
     if (!await isLoggedIn()) {
         return redirect("/login")

--- a/src/app/feeds/atom/route.ts
+++ b/src/app/feeds/atom/route.ts
@@ -1,8 +1,9 @@
 import {getFeed} from "@/lib/data/feed";
 
-export const dynamic = 'force-static'
+export const dynamic = 'force-dynamic'
 
 export async function GET() {
     const feed = await getFeed();
     return new Response(feed.atom1(), {headers: { 'Content-Type': 'application/atom+xml'}})
 }
+

--- a/src/app/feeds/atom/route.ts
+++ b/src/app/feeds/atom/route.ts
@@ -1,7 +1,5 @@
 import {getFeed} from "@/lib/data/feed";
 
-export const dynamic = 'force-dynamic'
-
 export async function GET() {
     const feed = await getFeed();
     return new Response(feed.atom1(), {headers: { 'Content-Type': 'application/atom+xml'}})

--- a/src/app/feeds/rss/route.ts
+++ b/src/app/feeds/rss/route.ts
@@ -1,7 +1,5 @@
 import {getFeed} from "@/lib/data/feed";
 
-export const dynamic = 'force-dynamic'
-
 export async function GET() {
     const feed = await getFeed();
     return new Response(feed.rss2(), {headers: { 'Content-Type': 'application/rss+xml'}})

--- a/src/app/feeds/rss/route.ts
+++ b/src/app/feeds/rss/route.ts
@@ -1,8 +1,9 @@
 import {getFeed} from "@/lib/data/feed";
 
-export const dynamic = 'force-static'
+export const dynamic = 'force-dynamic'
 
 export async function GET() {
     const feed = await getFeed();
     return new Response(feed.rss2(), {headers: { 'Content-Type': 'application/rss+xml'}})
 }
+

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,10 @@
 import type { Metadata } from "next";
 import "./globals.css";
-import amazonpaws from "@/resources/images/amazonpaws.svg"
+import amazonpaws from "@/resources/images/amazonpaws.svg";
 import Image from "next/image";
 import Link from "next/link";
+
+export const dynamic = 'force-dynamic';
 
 import { config } from '@fortawesome/fontawesome-svg-core'
 import '@fortawesome/fontawesome-svg-core/styles.css'

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,8 +3,6 @@ import {PawPrint} from "@/types/pawPrint";
 import PawTrack from "@/components/PawTrack";
 import {getPrints} from "@/lib/data";
 
-export const dynamic = 'force-dynamic'
-
 export default async function Home() {
   const prints: PawPrint[] = await getPrints();
   return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,8 @@ import {PawPrint} from "@/types/pawPrint";
 import PawTrack from "@/components/PawTrack";
 import {getPrints} from "@/lib/data";
 
+export const dynamic = 'force-dynamic'
+
 export default async function Home() {
   const prints: PawPrint[] = await getPrints();
   return (
@@ -12,3 +14,4 @@ export default async function Home() {
       </>
   );
 }
+

--- a/src/app/print/[slug]/page.tsx
+++ b/src/app/print/[slug]/page.tsx
@@ -3,6 +3,8 @@ import {notFound} from "next/navigation";
 import PawTrack from "@/components/PawTrack";
 import Link from "next/link";
 
+export const dynamic = 'force-dynamic'
+
 export async function generateMetadata({
     params,
 }: {

--- a/src/app/print/[slug]/page.tsx
+++ b/src/app/print/[slug]/page.tsx
@@ -3,8 +3,6 @@ import {notFound} from "next/navigation";
 import PawTrack from "@/components/PawTrack";
 import Link from "next/link";
 
-export const dynamic = 'force-dynamic'
-
 export async function generateMetadata({
     params,
 }: {

--- a/src/app/tags/[...slug]/page.tsx
+++ b/src/app/tags/[...slug]/page.tsx
@@ -1,6 +1,8 @@
 import {getPrints} from "@/lib/data";
 import PawTrack from "@/components/PawTrack";
 
+export const dynamic = 'force-dynamic'
+
 export async function generateMetadata({
     params,
 }: {

--- a/src/app/tags/[...slug]/page.tsx
+++ b/src/app/tags/[...slug]/page.tsx
@@ -1,8 +1,6 @@
 import {getPrints} from "@/lib/data";
 import PawTrack from "@/components/PawTrack";
 
-export const dynamic = 'force-dynamic'
-
 export async function generateMetadata({
     params,
 }: {

--- a/src/lib/data/index.ts
+++ b/src/lib/data/index.ts
@@ -1,13 +1,24 @@
 'use server';
 import {PawPrint} from "@/types/pawPrint";
-import {BSON, MongoClient, ObjectId, WithId} from "mongodb";
-import "../../envConfig"
+import {BSON, MongoClient, ObjectId, WithId, Collection} from "mongodb";
 import {unstable_cache, unstable_expireTag} from "next/cache";
 
-const mongo = new MongoClient(process.env.MONGO_URL!);
-await mongo.connect();
-const db = mongo.db(process.env.MONGO_DB || "paws");
-const collection = db.collection("prints");
+let client: MongoClient | null = null;
+let collection: Collection<BSON.Document> | null = null;
+
+async function getCollection() {
+    if (!collection) {
+        const url = process.env.MONGO_URL;
+        if (!url) {
+            throw new Error("MONGO_URL is not defined");
+        }
+        client = new MongoClient(url);
+        await client.connect();
+        const db = client.db(process.env.MONGO_DB || "paws");
+        collection = db.collection("prints");
+    }
+    return collection!;
+}
 
 function convert(response: WithId<BSON.Document>): PawPrint {
     return {
@@ -22,6 +33,7 @@ function convert(response: WithId<BSON.Document>): PawPrint {
 }
 
 export async function insertOrUpdate(print: PawPrint) {
+    const collection = await getCollection();
     let oid: ObjectId
     if (print.id) {
         // Update
@@ -41,6 +53,7 @@ export async function insertOrUpdate(print: PawPrint) {
 }
 
 export async function deletePrint(id: string) {
+    const collection = await getCollection();
     await collection.deleteOne({_id: new ObjectId(id)})
     unstable_expireTag("prints")
 }
@@ -51,6 +64,7 @@ export async function deletePrint(id: string) {
  * Invalidate the cache with the `prints` key.
  */
 export const getPrint = unstable_cache(async (id: string): Promise<PawPrint|null> => {
+    const collection = await getCollection();
     const result = await collection.findOne({_id: new ObjectId(id)})
     return result ? convert(result) : null;
 }, undefined, {
@@ -80,6 +94,7 @@ export const getPrints = unstable_cache(async (
             $in: tags
         }
     }
+    const collection = await getCollection();
     let cursor = collection.find(query).sort({"date": -1})
     if (maxResults) {
         cursor = cursor.limit(maxResults).skip(pagination)
@@ -90,3 +105,4 @@ export const getPrints = unstable_cache(async (
     revalidate: 500,
     tags: ["prints"]
 })
+

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -2,21 +2,35 @@ import 'server-only'
 import { SignJWT, jwtVerify } from 'jose'
 import { SessionPayload } from '@/types/sessionPayload'
 import {cookies} from "next/headers";
+import { randomBytes } from "crypto";
 
-const secretKey = process.env.SECRET_KEY
-const encodedKey = new TextEncoder().encode(secretKey)
+let encodedKey: Uint8Array | null = null;
+
+function getEncodedKey() {
+    if (!encodedKey) {
+        let secret = process.env.SECRET_KEY;
+        if (!secret) {
+            console.log('Generating secret key');
+            secret = randomBytes(16).toString('hex');
+        }
+        encodedKey = new TextEncoder().encode(secret);
+    }
+    return encodedKey;
+}
 
 export async function encrypt(payload: SessionPayload) {
+    const key = getEncodedKey();
     return new SignJWT(payload)
         .setProtectedHeader({ alg: 'HS256' })
         .setIssuedAt()
         .setExpirationTime('7d')
-        .sign(encodedKey)
+        .sign(key)
 }
 
 export async function decrypt(session: string | undefined = '') {
     try {
-        const { payload } = await jwtVerify(session, encodedKey, {
+        const key = getEncodedKey();
+        const { payload } = await jwtVerify(session, key, {
             algorithms: ['HS256'],
         })
         return payload
@@ -68,3 +82,4 @@ export async function isLoggedIn(): Promise<boolean> {
 
     return session?.login == true
 }
+


### PR DESCRIPTION
## Summary
- lazily connect to MongoDB to avoid build-time env requirement
- generate SECRET_KEY at runtime if missing
- force dynamic rendering for pages and routes that need runtime data

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684c89c8e7e483229fa372eb05053639